### PR TITLE
Add support for Privilege API

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,74 @@ $sent = $client->sendInviteLink("user@example.com");
 /* Get Apps to Embed for a User */
 $embedToken = "30e256c101cd0d2e731de1ec222e93c4be8a1578";
 $apps = $client->getEmbedApps($embedToken, "user@example.com");
+
+/* Get Privileges */
+$privileges = $client->getPrivileges();
+
+/* Create Privilege */
+$name = "privilege_example";
+$version = "2018-05-18";
+
+$statement1 = new Statement(
+    "Allow",
+    [
+        "users:List",
+        "users:Get",
+    ],
+    ["*"]
+);
+
+$statement2 = new Statement(
+    "Allow",
+    [
+        "apps:List",
+        "apps:Get",
+    ],
+    ["*"]
+);
+
+$statements = array(
+    $statement1,
+    $statement2
+);
+
+$privilege = $client->createPrivilege($name, $version, $statements);
+
+/* Update Privilege */
+$name = "privilege_example_updated";
+$statement2 = new Statement(
+    "Allow",
+    [
+        "apps:List",
+    ],
+    ["*"]
+);
+$privilege = $client->updatePrivilege($privilege->id, $name, $version, $statements);
+
+/* Get Privilege */
+$privilege = $client->getPrivilege($privilege->id);
+
+/* Delete Privilege */
+$result = $client->deletePrivilege($privilege->id);
+
+/* Gets a list of the roles assigned to a privilege */
+$assignedRoles = $client->getRolesAssignedToPrivilege($privilege->id);
+
+/* Assign roles to a privilege */
+$result = $client->assignRolesToPrivilege($privilege->id, array($role_id1, $role_id2));
+
+/* Remove role from a privilege */
+$result = $client->removeRoleFromPrivilege($privilege->id, $role_id1);
+
+/* Gets a list of the users assigned to a privilege */
+$assignedUsers = $client->getUsersAssignedToPrivilege($privilege->id);
+
+/* Assign users to a privilege */
+$result = $client->assignUsersToPrivilege($privilege->id, array($user_id1, $user_id2));
+
+/* Remove user from a privilege */
+$result = $client->removeUserFromPrivilege($privilege->id, $user_id2);
+
 ```
 
 ## Development

--- a/src/models/Privilege.php
+++ b/src/models/Privilege.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace OneLogin\api\models;
+
+use OneLogin\api\models\Statement;
+use OneLogin\api\util\Constants;
+
+class Privilege
+{
+    /** @var int */
+    public $id;
+
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $version;
+
+    /** @var array */
+    public $statements = array();
+
+    /**
+     * Create a new instance of Privilege.
+     */
+    public function __construct()
+    {
+        $get_arguments       = func_get_args();
+        $number_of_arguments = func_num_args();
+
+        if (method_exists($this, $method_name = '__construct'.$number_of_arguments)) {
+            call_user_func_array(array($this, $method_name), $get_arguments);
+        }
+    }
+
+    public function __construct1($data)
+    {
+        $this->id = $data->id;
+        $this->name = $data->name;
+        $this->version = $data->privilege->Version;
+        foreach ($data->privilege->Statement as $statementData) {
+            $this->statements[] = new Statement($statementData);
+        }
+    }
+
+    /**
+     * Create a new instance of Privilege.
+     */
+    public function __construct4($id, $name, $version, $statements)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->version = $version;
+        $this->statements = array();
+
+        foreach ($statements as $statement) {
+            if (is_object($statement)) {
+                $this->statements[] = $statement;
+            } else if (is_array($statement) && array_key_exists("Effect", $statement) && array_key_exists("Action", $statement) && array_key_exists("Scope", $statement)) {
+                $this->statements[] = new Statement($statement["Effect"], $statement["Action"], $statement["Scope"]);
+            }
+        }
+
+        $this->statements = $this->statements;
+    }
+
+    public static function getValidActions()
+    {
+        return Constants::VALID_ACTIONS;
+    }
+}

--- a/src/models/Statement.php
+++ b/src/models/Statement.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OneLogin\api\models;
+
+class Statement
+{
+    /** @var string */
+    public $effect;
+
+    /** @var array */
+    public $actions;
+
+    /** @var array */
+    public $scopes;
+
+    /**
+     * Create a new instance of Statement.
+     */
+    public function __construct()
+    {
+        $get_arguments       = func_get_args();
+        $number_of_arguments = func_num_args();
+
+        if (method_exists($this, $method_name = '__construct'.$number_of_arguments)) {
+            call_user_func_array(array($this, $method_name), $get_arguments);
+        }
+    }
+
+    public function __construct1($data)
+    {
+        $this->effect = isset($data->Effect)? $data->Effect : "Allow";
+        $this->actions = $data->Action;
+        $this->scopes = $data->Scope;
+    }
+
+    public function __construct3($effect, $actions, $scopes)
+    {
+        $this->effect = $effect;
+        $this->actions = $actions;
+        $this->scopes = $scopes;
+    }
+}

--- a/src/util/Constants.php
+++ b/src/util/Constants.php
@@ -12,7 +12,7 @@ class Constants
     // OAuth2 Tokens URLs
     const TOKEN_REQUEST_URL = "https://api.%s.onelogin.com/auth/oauth2/v2/token";
     const TOKEN_REFRESH_URL = "https://api.%s.onelogin.com/auth/oauth2/v2/token";
-    const TOKEN_REVOKE_URL = "https://api.%s.onelogin.com/auth/oauth2/revoke";
+    const TOKEN_REVOKE_URL = "https://api.%s.onelogin.com/auth/oauth2/v2/revoke";
     const GET_RATE_URL = "https://api.%s.onelogin.com/auth/rate_limit";
 
     // User URLs
@@ -69,4 +69,90 @@ class Constants
 
     // Embed Apps URL
     const EMBED_APP_URL = "https://api.onelogin.com/client/apps/embed2";
+
+    // Privileges URLS
+    const LIST_PRIVILEGES_URL = "https://api.%s.onelogin.com/api/1/privileges";
+    const CREATE_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges";
+    const UPDATE_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s";
+    const GET_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s";
+    const DELETE_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s";
+    const GET_ROLES_ASSIGNED_TO_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s/roles";
+    const ASSIGN_ROLES_TO_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s/roles";
+    const REMOVE_ROLE_FROM_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s/roles/%s";
+    const GET_USERS_ASSIGNED_TO_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s/users";
+    const ASSIGN_USERS_TO_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s/users";
+    const REMOVE_USER_FROM_PRIVILEGE_URL = "https://api.%s.onelogin.com/api/1/privileges/%s/users/%s";
+    const VALID_ACTIONS = array(
+        "apps:List",
+        "apps:Get",
+        "apps:Create",
+        "apps:Update",
+        "apps:Delete",
+        "apps:ManageRoles",
+        "apps:ManageUsers",
+        "directories:List",
+        "directories:Get",
+        "directories:Create",
+        "directories:Update",
+        "directories:Delete",
+        "directories:SyncUsers",
+        "directories:RefreshSchema",
+        "events:List",
+        "events:Get",
+        "mappings:List",
+        "mappings:Get",
+        "mappings:Create",
+        "mappings:Update",
+        "mappings:Delete",
+        "mappings:ReapplyAll",
+        "policies:List",
+        "policies:user:Get",
+        "policies:user:Create",
+        "policies:user:Update",
+        "policies:user:Delete",
+        "policies:app:Get",
+        "policies:app:Create",
+        "policies:app:Update",
+        "policies:app:Delete",
+        "privileges:List",
+        "privileges:Get",
+        "privileges:Create",
+        "privileges:Update",
+        "privileges:Delete",
+        "privileges:ListUsers",
+        "privileges:ListRoles",
+        "privileges:ManageUsers",
+        "privileges:ManageRoles",
+        "reports:List",
+        "reports:Get",
+        "reports:Create",
+        "reports:Update",
+        "reports:Delete",
+        "reports:Run",
+        "roles:List",
+        "roles:Get",
+        "roles:Create",
+        "roles:Update",
+        "roles:Delete",
+        "roles:ManageUsers",
+        "roles:ManageApps",
+        "trustedidp:List",
+        "trustedidp:Get",
+        "trustedidp:Create",
+        "trustedidp:Update",
+        "trustedidp:Delete",
+        "users:List",
+        "users:Get",
+        "users:Create",
+        "users:Update",
+        "users:Delete",
+        "users:Unlock",
+        "users:ResetPassword",
+        "users:ForceLogout",
+        "users:Invite",
+        "users:ReapplyMappings",
+        "users:ManageRoles",
+        "users:ManageApps",
+        "users:GenerateTempMfaToken"
+    );
 }


### PR DESCRIPTION
- Add Privilege methods.
- Remove the ":" from the Authorization header at the getAuthorization method.
- Modify getBeforeCursor, getAfterCursor, handleOperationResponse and extractErrorMessageFromResponse methods to support the new API result format.