### PR TITLE
Get a session status when trying to send out a otpToken.

### DIFF
--- a/src/models/SessionStatus.php
+++ b/src/models/SessionStatus.php
@@ -1,0 +1,29 @@
+<?php
+namespace OneLogin\api\models;
+
+class SessionStatus
+{
+
+    /** @var string */
+    public $type;
+
+    /** @var int */
+    public $code;
+
+    /** @var string */
+    public $message;
+
+    /** @var bool */
+    public $error;
+
+    /**
+     * Create a new instance of SessionStatus.
+     */
+    public function __construct($status)
+    {
+        $this->type    = $status->type;
+        $this->code    = $status->code;
+        $this->message = $status->message;
+        $this->error   = $status->error;
+    }
+}


### PR DESCRIPTION
Currently nothing is returned by getSessionTokenVerified when trying to send a otp token to the user. Like with SMS or Email. But it would be good if we could get the message sent from the API to display it to the user.

This change adds a SessionStatus object that is returned when calling getSessionTokenVerified only with the required parameters.