### PR TITLE
Added support for guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^5.3.1|^6.2",
+        "guzzlehttp/guzzle": "^5.3.1|^6.2|7.0",
         "guzzlehttp/psr7": "^1.4.1"
     },
     "suggest": {


### PR DESCRIPTION
Added support for guzzle 7.0

The Laravel 8 required guzzle 7.0 https://laravel.com/docs/8.x/upgrade#updating-dependencies, So, this repo is blocking to upgrade to Laravel 8. Could you please review and approve ASAP?

Thanks.

