### PR TITLE
Support guzzle >7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^5.3.1|^6.2|7.0",
+        "guzzlehttp/guzzle": "^5.3.1|^6.2|^7.0",
         "guzzlehttp/psr7": "^1.4.1"
     },
     "suggest": {


### PR DESCRIPTION
The current dependency restrictions allow only the particular version `7.0` of `guzzlehttp/guzzle`. The PR is changing the configuration to allow for all 7.x versions of guzzlehttp