### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/OneLoginClient.php
+++ b/src/OneLoginClient.php
@@ -45,8 +45,8 @@ class OneLoginClient
     /** @var GuzzleHttp\Client client  */
     protected $client;
 
-    /** @var string $clientID OneLogin Client ID */
-    public $clientID;
+    /** @var string $clientId OneLogin Client ID */
+    public $clientId;
 
     /** @var string $clientSecret OneLogin Client  */
     public $clientSecret;

--- a/src/exceptions/OneLoginException.php
+++ b/src/exceptions/OneLoginException.php
@@ -13,7 +13,7 @@ class OneLoginException extends \Exception
     /** @var string $errorAttribute The attribute that caused the error if available */
     protected $errorAttribute;
 
-    public function __construct($message = "", $code = 0, $errorAttribute = null, \Throwable $previous = null)
+    public function __construct($message = "", $code = 0, $errorAttribute = null, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->errorCode = $code;


### PR DESCRIPTION
Fix these deprecation warnings:
- `Creation of dynamic property OneLogin\api\OneLoginClient::$clientId`
  - https://www.php.net/manual/en/migration82.deprecated.php 
- `Implicitly nullable parameter: $previous`
  - https://www.php.net/manual/en/migration84.deprecated.php